### PR TITLE
Add decision-oriented runner

### DIFF
--- a/actions/__init__.py
+++ b/actions/__init__.py
@@ -1,0 +1,36 @@
+"""High level action wrappers used by the runner.
+
+The functions exposed here are intentionally small and synchronous.  They
+thinly wrap calls to the :class:`OpenAPIService` so the runner only needs
+compose decision logic and is not tied to the underlying API client.
+"""
+
+from __future__ import annotations
+
+from services.client_service import OpenAPIService
+from openapi_client.models.navigate_ship_request import NavigateShipRequest
+
+
+def list_ships(svc: OpenAPIService):
+    """Return the agent's ships using the Fleet API."""
+
+    return svc.d.fleet.get_my_ships()
+
+
+def orbit(svc: OpenAPIService, ship_symbol: str):
+    """Move ``ship_symbol`` into orbit."""
+
+    return svc.d.fleet.orbit_ship(ship_symbol)
+
+
+def dock(svc: OpenAPIService, ship_symbol: str):
+    """Dock ``ship_symbol`` at its current waypoint."""
+
+    return svc.d.fleet.dock_ship(ship_symbol)
+
+
+def navigate(svc: OpenAPIService, ship_symbol: str, destination: str):
+    """Navigate ``ship_symbol`` to ``destination`` waypoint."""
+
+    req = NavigateShipRequest(waypoint_symbol=destination)
+    return svc.d.fleet.navigate_ship(ship_symbol, navigate_ship_request=req)

--- a/etl/__init__.py
+++ b/etl/__init__.py
@@ -1,0 +1,53 @@
+"""Simple in-memory state helpers for runner.
+
+This module provides tiny helpers for the runner script so that the
+runner's decision logic can track the latest view of ship state without
+concerning itself with persistence.  It uses the :class:`ShipState`
+model from :mod:`runner_state` and stores instances in a module level
+cache.
+
+The functions are intentionally lightweight; a more complete
+implementation would likely sync state to a database.  For the purpose
+of the unit tests and the runner example they provide just enough
+functionality.
+"""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from runner_state import ShipState
+
+# Internal cache of ship state keyed by ship symbol
+_SHIPS: Dict[str, ShipState] = {}
+
+
+def update_from_api(ship: object) -> ShipState:
+    """Create :class:`ShipState` from an API ship object and cache it.
+
+    Parameters
+    ----------
+    ship:
+        Object returned from the OpenAPI client representing a ship.
+
+    Returns
+    -------
+    ShipState
+        The normalised state for the ship.
+    """
+
+    state = ShipState.from_api(ship)
+    _SHIPS[state.symbol] = state
+    return state
+
+
+def get_ship(symbol: str) -> ShipState | None:
+    """Return cached state for ``symbol`` if available."""
+
+    return _SHIPS.get(symbol)
+
+
+def all_ships() -> Dict[str, ShipState]:
+    """Return a shallow copy of the entire ship state cache."""
+
+    return dict(_SHIPS)

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,42 @@
+"""Example runner script focused on decision logic.
+
+The goal of the runner is to orchestrate game play while delegating
+persistence to :mod:`etl` and concrete API calls to :mod:`actions`.
+It performs a very small set of decisions just to demonstrate the
+pattern: fetch the agent's ships, update local state, and ensure each
+ship is in orbit.
+
+This file intentionally avoids embedding business rules beyond that
+minimal example; real strategies should live in separate modules.
+"""
+
+from __future__ import annotations
+
+from dotenv import load_dotenv
+
+import actions
+import etl
+from services.client_service import OpenAPIService
+
+
+load_dotenv()
+
+
+def run() -> None:
+    """Run a minimal decision loop.
+
+    - Retrieve the player's ships using :func:`actions.list_ships`
+    - Normalise and store each ship's state via :func:`etl.update_from_api`
+    - If a ship is not already in orbit, call :func:`actions.orbit`
+    """
+
+    svc = OpenAPIService()
+    ships = actions.list_ships(svc)
+    for ship in ships:
+        state = etl.update_from_api(ship)
+        if state.nav_status != "IN_ORBIT":
+            actions.orbit(svc, state.symbol)
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- create simple runner that delegates state to `etl` and uses `actions` wrappers
- add lightweight `etl` state cache
- provide action helpers wrapping `OpenAPIService`

## Testing
- `pre-commit run --files runner.py etl/__init__.py actions/__init__.py` *(fails: command not found)*
- `pytest tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b839601d3c832f9c176401858b87a0