### PR TITLE
Add reusable fleet action helpers

### DIFF
--- a/services/actions.py
+++ b/services/actions.py
@@ -1,0 +1,49 @@
+"""Reusable action helper functions."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from . import api_groups
+from openapi_client.models.navigate_ship_request import NavigateShipRequest
+from openapi_client.models.sell_cargo_request import SellCargoRequest
+from openapi_client.models.refuel_ship_request import RefuelShipRequest
+
+
+def navigate_ship(
+    ship_symbol: str,
+    waypoint_symbol: str,
+    api: Any = api_groups.etl,
+):
+    """Navigate a ship to the given waypoint."""
+    req = NavigateShipRequest(waypointSymbol=waypoint_symbol)
+    return api.fleet.navigate_ship(ship_symbol, req)
+
+
+def sell_cargo(
+    ship_symbol: str,
+    good_symbol: str,
+    units: int,
+    api: Any = api_groups.etl,
+):
+    """Sell cargo from a ship."""
+    req = SellCargoRequest(symbol=good_symbol, units=units)
+    return api.fleet.sell_cargo(ship_symbol, req)
+
+
+def refuel_ship(
+    ship_symbol: str,
+    units: Optional[int] = None,
+    from_cargo: Optional[bool] = None,
+    api: Any = api_groups.etl,
+):
+    """Refuel a ship, optionally specifying units or drawing from cargo."""
+    request = None
+    if units is not None or from_cargo is not None:
+        request = RefuelShipRequest(units=units, fromCargo=from_cargo)
+        return api.fleet.refuel_ship(ship_symbol, request)
+    return api.fleet.refuel_ship(ship_symbol)
+
+
+__all__ = ["navigate_ship", "sell_cargo", "refuel_ship"]
+

--- a/services/api_groups.py
+++ b/services/api_groups.py
@@ -17,3 +17,6 @@ global_api = svc.d.global_api  # GlobalApi → global_api alias
 
 # If you also want raw (non-data-proxy) access:
 raw = svc.apis
+
+# Expose the full data-proxy namespace for convenience in helper functions
+etl = svc.d


### PR DESCRIPTION
## Summary
- expose `etl` alias in `services.api_groups`
- add `services.actions` with helpers `navigate_ship`, `sell_cargo`, and `refuel_ship`

## Testing
- `python -m py_compile services/actions.py`
- `python -m py_compile services/api_groups.py`
- `pre-commit run --files services/actions.py services/api_groups.py` *(fails: command not found)*
- `pytest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8395edc28832fbf0d3bd05a4a6e38